### PR TITLE
Sub pages implementation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ export default function App() {
       y: 0,
       type: null,
       categoryId: null,
+      pageId: null, // NEW
     });
 
   const [iconPicker, setIconPicker] =
@@ -122,6 +123,9 @@ export default function App() {
           setContextMenu={setContextMenu}
           createCategory={actions.createCategory}
           createPage={actions.createPage}
+          createSubpage={actions.createSubpage}          // NEW
+          movePageToParent={actions.movePageToParent}   // NEW
+          togglePageExpanded={actions.togglePageExpanded} // NEW
           deleteCategory={actions.deleteCategory}
           updateCategoryName={actions.updateCategoryName}
           toggleCategoryExpanded={actions.toggleCategoryExpanded}

--- a/src/components/CategoryItem.tsx
+++ b/src/components/CategoryItem.tsx
@@ -23,6 +23,10 @@ interface CategoryItemProps {
   deletePage: (pageId: string) => void;
   setActivePageId: (pageId: string) => void;
   setContextMenu: React.Dispatch<React.SetStateAction<ContextMenuState>>;
+  togglePageExpanded: (pageId: string) => void;
+  onPageDragOver?: (pageId: string) => void;
+  onPageDragLeave?: () => void;
+  dragTargetPageId?: string | null;
 }
 
 export default function CategoryItem({
@@ -34,6 +38,10 @@ export default function CategoryItem({
   deletePage,
   setActivePageId,
   setContextMenu,
+  togglePageExpanded,
+  onPageDragOver,
+  onPageDragLeave,
+  dragTargetPageId,
 }: CategoryItemProps) {
   const {
     setNodeRef,
@@ -131,6 +139,11 @@ export default function CategoryItem({
                   setActivePageId={setActivePageId}
                   deletePage={deletePage}
                   openIconPicker={openIconPicker}
+                  togglePageExpanded={togglePageExpanded}
+                  setContextMenu={setContextMenu}
+                  onDragOver={onPageDragOver}
+                  onDragLeave={onPageDragLeave}
+                  isDragTarget={dragTargetPageId === page.id}
                 />
               ))}
           </div>

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -12,8 +12,10 @@ interface ContextMenusProps {
     id?: string,
     title?: string,
     switchTo?: boolean,
-    type?: PageType
+    type?: PageType,
+    parentId?: string | null
   ) => void;
+  createSubpage?: (parentPageId: string, type?: PageType) => void;
   deleteCategory: (categoryId: string) => void;
   updateCategoryName: (categoryId: string, newName: string) => void;
   setCategoryFolder: (categoryId: string) => void | Promise<void>;
@@ -24,6 +26,7 @@ export default function ContextMenus({
   setContextMenu,
   createCategory,
   createPage,
+  createSubpage,
   deleteCategory,
   setCategoryFolder,
 }: ContextMenusProps) {
@@ -36,6 +39,7 @@ export default function ContextMenus({
       y: 0,
       type: null,
       categoryId: null,
+      pageId: null,
     });
 
   const position = {
@@ -45,56 +49,91 @@ export default function ContextMenus({
     zIndex: 9999,
   };
 
+  // NEW: Page context menu
+  if (contextMenu.type === "page" && contextMenu.pageId) {
+    return (
+      <div
+        className="context-menu"
+        style={position}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          onClick={() => {
+            if (createSubpage) {
+              createSubpage(contextMenu.pageId!, "note");
+            }
+            close();
+          }}
+        >
+          <Icon icon="material-symbols:new-window-rounded" width="16" height="16" color="#fff" />
+          Add Subpage
+        </button>
+
+        <button
+          onClick={() => {
+            if (createSubpage) {
+              createSubpage(contextMenu.pageId!, "channel");
+            }
+            close();
+          }}
+        >
+          <Icon icon="material-symbols:videocam-outline" width="16" height="16" color="#fff" />
+          Add Sub-Channel
+        </button>
+      </div>
+    );
+  }
+
   if (contextMenu.type === "category")
-  return (
-    <div
-      className="context-menu"
-      style={position}
-      onClick={(e) => e.stopPropagation()}
-    >
-      <button
-        onClick={() => {
-          createPage(contextMenu.categoryId!); 
-          close();
-        }}
+    return (
+      <div
+        className="context-menu"
+        style={position}
+        onClick={(e) => e.stopPropagation()}
       >
-        <Icon icon="material-symbols:new-window-rounded" width="16" height="16" color="#fff" />
-        Add Page
-      </button>
+        <button
+          onClick={() => {
+            createPage(contextMenu.categoryId!); 
+            close();
+          }}
+        >
+          <Icon icon="material-symbols:new-window-rounded" width="16" height="16" color="#fff" />
+          Add Page
+        </button>
 
-      <button
-        onClick={() => {
-          createPage(contextMenu.categoryId!, undefined, undefined, true, "channel");
-          close();
-        }}
-      >
-        <Icon icon="material-symbols:videocam-outline" width="16" height="16" color="#fff" />
-        Add Channel
-      </button>
+        <button
+          onClick={() => {
+            createPage(contextMenu.categoryId!, undefined, undefined, true, "channel");
+            close();
+          }}
+        >
+          <Icon icon="material-symbols:videocam-outline" width="16" height="16" color="#fff" />
+          Add Channel
+        </button>
 
-      <button
-        onClick={() => {
-          deleteCategory(contextMenu.categoryId!);
-          close();
-        }}
-      >
-        <Icon icon="material-symbols:delete-outline-rounded" width="16" height="16" color="#fff" />
-        Delete
-      </button>
+        <button
+          onClick={() => {
+            deleteCategory(contextMenu.categoryId!);
+            close();
+          }}
+        >
+          <Icon icon="material-symbols:delete-outline-rounded" width="16" height="16" color="#fff" />
+          Delete
+        </button>
 
-      <hr color="#686E7C" />
+        <hr color="#686E7C" />
 
-      <button
-        onClick={() => {
-          setCategoryFolder(contextMenu.categoryId!);
-          close();
-        }}
-      >
-        <Icon icon="ic:baseline-drive-folder-upload" width="16" height="16" color="#fff" />
-        Choose Folder...
-      </button>
-    </div>
-  );
+        <button
+          onClick={() => {
+            setCategoryFolder(contextMenu.categoryId!);
+            close();
+          }}
+        >
+          <Icon icon="ic:baseline-drive-folder-upload" width="16" height="16" color="#fff" />
+          Choose Folder...
+        </button>
+      </div>
+    );
 
   if (contextMenu.type === "sidebar")
     return (

--- a/src/index.css
+++ b/src/index.css
@@ -127,7 +127,8 @@ body {
 .category-header {
   display: flex;
   align-items: center;
-  border-radius: 8px
+  border-radius: 8px;
+  transition: all 0.3s ease;
 }
 
 .category-header input {
@@ -165,6 +166,64 @@ body {
   margin-left: .5rem
 }
 
+/* ---------- NESTED PAGE STYLES ---------- */
+
+/* Page toggle button (expand/collapse) */
+.page-toggle {
+  background: none;
+  border: none;
+  color: var(--text3);
+  cursor: pointer;
+  padding: 0 4px;
+  font-size: 12px;
+  width: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s;
+  flex-shrink: 0;
+}
+
+.page-toggle:hover {
+  color: var(--text0);
+}
+
+.page-toggle-spacer {
+  width: 20px;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+/* Tree node container */
+.tree-node {
+  position: relative;
+}
+
+/* Page children container */
+.page-children {
+  position: relative;
+}
+
+/* Drag target highlight */
+.page-item.drag-target {
+  background-color: rgba(99, 102, 241, 0.2);
+  border-left: 3px solid #6366f1;
+}
+
+.page-item.drag-target::after {
+  content: "Drop to nest";
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 11px;
+  color: #6366f1;
+  font-weight: 500;
+  pointer-events: none;
+}
+
+/* ---------- END NESTED PAGE STYLES ---------- */
+
 .page-item {
   display: flex;
   align-items: center;
@@ -174,6 +233,9 @@ body {
   cursor: pointer;
   font-size: 1rem;
   color: var(--text2);
+  transition: all 0.1s ease;
+  margin-top: 2px;
+  position: relative;
 }
 
 .page-item:hover {
@@ -202,7 +264,7 @@ body {
   border-radius: var(--radius);
   font-size: 1.1rem;
   opacity: 0;
-  transition: all .2s
+  transition: opacity .2s ease;
 }
 
 .page-item:hover .delete-page-btn {
@@ -212,6 +274,17 @@ body {
 .delete-page-btn:hover {
   background: var(--red);
   color: var(--bg0)
+}
+
+.drag-handle {
+  color: var(--text3);
+  cursor: grab;
+  user-select: none;
+  flex-shrink: 0;
+}
+
+.drag-handle:active {
+  cursor: grabbing;
 }
 
 /* ---------- main ---------- */
@@ -458,10 +531,6 @@ body {
   color: #61afef;
 }
 
-.category-header {
-  transition: all 0.3s ease;
-}
-
 .pages-container {
   overflow: hidden;
   transition:
@@ -482,11 +551,6 @@ body {
   max-height: 1000px;
   transform: translateY(0);
   visibility: visible;
-}
-
-.page-item {
-  transition: all 0.1s ease;
-  margin-top: 2px;
 }
 
 .channel-page {
@@ -573,35 +637,8 @@ video {
 
 /* container that holds pages */
 .pages-list {
-  padding-left: 16px;
+  padding-left: 0;
   position: relative;
-}
-
-/* each tree node */
-.tree-node {
-  position: relative;
-}
-
-/* vertical line */
-.tree-node::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: -8px;
-  width: 1px;
-  background: #555;
-}
-
-/* horizontal connector */
-.tree-node > .page-item::before {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: -8px;
-  width: 8px;
-  height: 1px;
-  background: #555;
 }
 
 .side-container {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -10,6 +10,7 @@ function normalizePages(pages: any[]) {
   return pages.map((page) => ({
     ...page,
     parentId: page.parentId ?? null,
+    isExpanded: page.isExpanded ?? true, // NEW: Default pages to expanded
   }));
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,9 +6,10 @@ export type Page = {
   icon?: string;
   blocks: any[];
   categoryId: string;
-    type: PageType;
+  type: PageType;
   parentId: string | null;
   children?: Page[];
+  isExpanded?: boolean; // NEW: Track if page's children are visible
 };
 
 export type Category = {
@@ -24,8 +25,9 @@ export type ContextMenuState = {
   visible: boolean;
   x: number;
   y: number;
-  type: "category" | "sidebar" | null;
+  type: "category" | "sidebar" | "page" | null; // NEW: Added "page" type
   categoryId: string | null;
+  pageId?: string | null; // NEW: Track which page was right-clicked
 };
 
 export type IconPickerState = {


### PR DESCRIPTION
# Pull Request: Add Nested Pages Functionality

## 📋 Summary
Implemented full support for hierarchical page nesting, allowing pages to be organized as parent-child relationships within categories. Users can now create subpages and nest existing pages through both context menus and drag-and-drop interactions.

## ✨ Features Added

### 1. **Page Nesting via Drag & Drop**
- Drag a page and hold it over another page for >500ms to nest it as a child
- Visual feedback with "Drop to nest" indicator when hovering over valid drop targets
- Prevents circular nesting (cannot nest a page under its own descendants)
- Maintains page reordering for pages at the same hierarchy level

### 2. **Context Menu Enhancements**
- **New "Page" context menu type** - Right-click on any page to access page-specific actions
- **"Add Subpage"** - Creates a new note page nested under the selected page
- **"Add Sub-Channel"** - Creates a new channel page nested under the selected page

### 3. **Expand/Collapse for Pages**
- Pages with children display a toggle button (▸/▾) similar to categories
- Click to expand/collapse child pages
- Expansion state persists across sessions
- Children automatically expand when a page becomes a parent

### 4. **Smart Delete Behavior**
- When deleting a page with children, child pages are promoted to the deleted page's parent level
- Prevents orphaned pages
- Maintains data integrity throughout the hierarchy

### 5. **Visual Hierarchy Indicators**
- Child pages are indented 16px per level
- Smooth transitions for expand/collapse animations
- Clear visual distinction between parent and child pages

## 📁 Files Modified

### **Core Type Definitions**
#### `src/types.ts`
- Added `isExpanded?: boolean` to `Page` type for tracking child visibility
- Added `"page"` as a valid context menu type
- Added `pageId?: string | null` to `ContextMenuState` for page-specific context menus

### **Component Updates**
#### `src/components/PageItem.tsx`
- Added expand/collapse toggle button for pages with children
- Implemented recursive rendering of child pages
- Added drag target visual feedback
- Added context menu support with right-click
- Added hover state for delete button
- Prop additions:
  - `togglePageExpanded` - Function to toggle page expansion
  - `setContextMenu` - Enable page context menu
  - `onDragOver` / `onDragLeave` - Drag target tracking
  - `isDragTarget` - Visual feedback for drag operations

#### `src/components/CategoryItem.tsx`
- Pass `togglePageExpanded` to child PageItem components
- Pass drag-related props for nested page support
- Filter root-level pages (where `parentId === null`)

#### `src/components/Sidebar.tsx`
- Enhanced drag & drop logic to support page nesting
- Added `handleDragStart` to track drag duration
- Added `handleDragOver` for real-time drag target detection
- Updated `handleDragEnd` to handle both nesting and reordering
- Added state for `dragTargetPageId` to highlight drop zones
- New props:
  - `createSubpage` - Create child pages
  - `movePageToParent` - Move pages in hierarchy
  - `togglePageExpanded` - Control page expansion

#### `src/components/ContextMenu.tsx`
- Added new page context menu rendering
- Added "Add Subpage" and "Add Sub-Channel" menu items
- Updated close function to reset `pageId` state
- Optional `createSubpage` prop for subpage creation

### **Hook Updates**
#### `src/hooks/useActions.ts`
- **New function: `createSubpage(parentPageId, type)`**
  - Creates a new page nested under a specified parent
  - Automatically expands parent page to show new child
  
- **New function: `movePageToParent(pageId, newParentId)`**
  - Moves a page to a new parent (or to root level if `newParentId` is null)
  - Automatically expands new parent page
  - Prevents circular nesting

- **New function: `togglePageExpanded(pageId)`**
  - Toggles the expansion state of pages with children

- **Updated: `createPage()`**
  - Added optional `parentId` parameter (defaults to `null`)
  - Sets `isExpanded: true` by default for new pages

- **Updated: `deletePage()`**
  - Promotes children to deleted page's parent level
  - Prevents data loss and orphaned pages

### **Storage Layer**
#### `src/lib/storage.ts`
- Updated `normalizePages()` to set `isExpanded: true` by default
- Ensures backward compatibility with existing data
- Handles migration of pages without `isExpanded` property

### **Styling**
#### `src/index.css`
- Added `.page-toggle` and `.page-toggle-spacer` styles for expand/collapse buttons
- Added `.tree-node` and `.page-children` for hierarchical structure
- Added `.page-item.drag-target` for visual drag feedback
- Added `.drag-handle` cursor states (grab/grabbing)
- Enhanced transitions for smooth expand/collapse animations
- Added "Drop to nest" pseudo-element indicator
- Improved delete button opacity transitions
- Removed conflicting tree visualization styles
- Updated `.pages-list` padding to accommodate new structure

### **Application Entry Point**
#### `src/App.tsx`
- Updated `contextMenu` state initialization to include `pageId: null`
- Passed new action functions to Sidebar component:
  - `createSubpage`
  - `movePageToParent`
  - `togglePageExpanded`

## 🔄 Data Migration
- **Fully backward compatible** - Existing data without `isExpanded` or `parentId` properties will be normalized on load
- `parentId` defaults to `null` (root level pages)
- `isExpanded` defaults to `true` (expanded by default)

## 🎯 User Experience Improvements

### Interaction Methods
1. **Drag to Nest** - Hold a page over another for 0.5s
2. **Context Menu** - Right-click any page to add subpages
3. **Expand/Collapse** - Click ▸/▾ to show/hide children
4. **Visual Feedback** - Clear indicators for all drag states

### Visual Enhancements
- Indented hierarchy (16px per level)
- Animated expand/collapse transitions
- Drag target highlighting with text indicator
- Hover states for interactive elements
- Smooth delete button fade effects

## 🧪 Testing Checklist

- [x] Create subpage via context menu
- [x] Create sub-channel via context menu
- [x] Drag page to nest under another page
- [x] Expand/collapse pages with children
- [x] Delete parent page (children promoted)
- [x] Delete child page (no effect on siblings)
- [x] Prevent nesting page under its own child
- [x] Reorder pages at same hierarchy level
- [x] Reorder categories (unchanged functionality)
- [x] Data persistence across sessions
- [x] Backward compatibility with existing data

## 🐛 Bug Fixes
- Fixed potential circular nesting by validating parent-child relationships
- Fixed drag duration tracking to distinguish between reordering and nesting
- Fixed page deletion to properly handle orphaned children

## 📊 Performance Considerations
- Recursive rendering is optimized with React keys
- Drag operations use throttled state updates
- Minimal re-renders through proper prop passing

## 🔮 Future Enhancements
- Keyboard shortcuts for nesting/unnesting pages
- Multi-select for batch operations
- Drag pages between categories
- Maximum nesting depth limit (optional)
- Breadcrumb navigation for deeply nested pages

## 📸 Screenshots
<!-- Add screenshots of the new features in action -->
- Drag-to-nest interaction with visual feedback
- Expanded page hierarchy showing multiple levels
- Page context menu with subpage options

## 🤝 Breaking Changes
**None** - This feature is fully backward compatible with existing data structures.

---

**Related Issues:** #[issue-number]  
**Reviewers:** @[reviewer-usernames]  
**Labels:** `enhancement`, `feature`, `ui-improvement`